### PR TITLE
Add support for expressions inside attributes

### DIFF
--- a/__tests__/fixtures/processable/conditional-classes/expected.js
+++ b/__tests__/fixtures/processable/conditional-classes/expected.js
@@ -1,0 +1,15 @@
+import { useBlockProps } from "@wordpress/block-editor";
+
+export default ({ attributes, setAttributes }) => {
+  const [meta, setMeta] = useEntityProp("postType", postType, "meta");
+
+  return (
+    <section {...useBlockProps()}>
+      <div
+        className={`hero ${attributes.test} hero--${attributes.heroType} ${attributes.isChecked ? "yes" : "no"}`}
+      ></div>
+
+      <div className={`flex flex-col--${meta.reversed ? "reverse" : ""}`}></div>
+    </section>
+  );
+};

--- a/__tests__/fixtures/processable/conditional-classes/expected.js
+++ b/__tests__/fixtures/processable/conditional-classes/expected.js
@@ -1,6 +1,13 @@
 import { useBlockProps } from "@wordpress/block-editor";
+import { useSelect } from "@wordpress/data";
+import { useEntityProp } from "@wordpress/core-data";
 
 export default ({ attributes, setAttributes }) => {
+  const postType = useSelect(
+    (select) => select("core/editor").getCurrentPostType(),
+    [],
+  );
+
   const [meta, setMeta] = useEntityProp("postType", postType, "meta");
 
   return (

--- a/__tests__/fixtures/processable/conditional-classes/expected.json
+++ b/__tests__/fixtures/processable/conditional-classes/expected.json
@@ -1,0 +1,14 @@
+{
+  "name": "custom/input",
+  "title": "Input",
+  "textdomain": "input",
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "version": "0.1.0",
+  "category": "theme",
+  "example": {},
+  "attributes": { "align": { "type": "string", "default": "full" } },
+  "supports": { "html": false, "align": ["full"] },
+  "editorScript": "file:./index.js",
+  "render": "file:./render.php"
+}

--- a/__tests__/fixtures/processable/conditional-classes/expected.php
+++ b/__tests__/fixtures/processable/conditional-classes/expected.php
@@ -1,0 +1,4 @@
+<section <?php echo get_block_wrapper_attributes(); ?>>
+  <div class="<?= "hero " . (($attributes['test'] ?? '')) . " hero--" . (($attributes['heroType'] ?? '')) . " " . (($attributes['isChecked'] ?? '') ? 'yes' : 'no'); ?>"></div>
+  <div class="<?= "flex flex-col--" . ((get_post_meta(get_the_ID(), 'reversed', true)) ? 'reverse' : ''); ?>"></div>
+</section>

--- a/__tests__/fixtures/processable/conditional-classes/input.html
+++ b/__tests__/fixtures/processable/conditional-classes/input.html
@@ -1,0 +1,7 @@
+<section>
+  <div
+    class="hero { attributes.test} hero--{attributes.heroType} {attributes.isChecked ? 'yes' : 'no'}"
+  ></div>
+
+  <div class="flex flex-col--{postMeta.reversed ? 'reverse' : ''}"></div>
+</section>

--- a/docs/docs/guides/expressions.mdx
+++ b/docs/docs/guides/expressions.mdx
@@ -1,0 +1,94 @@
+# Using logical expressions inside attributes
+
+**HTML To Gutenberg** supports using JavaScript-like expressions directly inside HTML attributes. These expressions are dynamically evaluated in both **JavaScript (for the editor)** and **PHP (for rendering on the front end)**.
+
+Because the same expression must work in both languages, there are a few rules and limitations you should follow.
+
+## Basic syntax
+
+Use curly braces `{}` inside attribute values to insert dynamic expressions. These expressions can include conditional logic and common data-binding variable references.
+
+```html
+<div
+  class="card card--{attributes.variant === 'featured' ? 'highlight' : 'normal'}"
+></div>
+```
+
+This will generate:
+
+**JS (editor):**
+
+```jsx
+<div
+  className={`card card--${attributes.variant === "featured" ? "highlight" : "normal"}`}
+/>
+```
+
+**PHP (render):**
+
+```php
+<div class="<?= "card card--" . (($attributes['variant'] ?? '') === 'featured' ? 'highlight' : 'normal'); ?>"></div>
+```
+
+## Referencing Data
+
+You can reference values the same way you would in [data binding](data-binding.mdx):
+
+- `attributes.key`
+- `postMeta.key`
+- `post.title`
+
+**Example:**
+
+```html
+<div
+  id="{attributes.id}"
+  class="{postMeta.theme === 'dark' ? 'theme-dark' : 'theme-light'}"
+></div>
+```
+
+## What won’t work
+
+Because the expressions must be valid **both in JS and PHP**, avoid language-specific features. For example:
+
+```html
+<!-- ❌ This will not work in PHP -->
+<div class="hero--{attributes.type.length < 20 ? 'short' : 'long'}"></div>
+```
+
+- `length` is a JavaScript property.
+- PHP uses `count()` or `strlen()` depending on the type, but that’s not interchangeable.
+
+## Multiple expressions per attribute
+
+You can include as many expressions as you want inside a single attribute string. Example:
+
+```html
+<div
+  class="hero hero--{attributes.variant} hero--{attributes.layout} {attributes.active ? 'is-active' : ''}"
+></div>
+```
+
+## Supported expression features
+
+| Feature                                 | Supported | Example                                 |
+| --------------------------------------- | --------- | --------------------------------------- |
+| Static strings                          | ✅        | `"hero"`                                |
+| Variable references                     | ✅        | `{attributes.title}`                    |
+| Ternary expressions                     | ✅        | `{attributes.type === 'x' ? 'a' : 'b'}` |
+| Property access                         | ✅        | `{post.title}`                          |
+| Short-circuit evaluation (`&&`, `\|\|`) | ❌        | `{attributes.isVisible && 'show'}`      |
+| `.length`, `count()`                    | ❌        | Avoid language-specific APIs            |
+
+### Why short-circuit logic is not supported
+
+Expressions like `{condition && 'value'}` or `{value || 'fallback'}` are common in JavaScript, but they **don’t translate reliably to PHP**. These expressions may return `false`, `null`, or even integers, and when inserted into HTML attributes in PHP, they won't behave as expected.
+
+✅ Instead, use explicit ternary logic:
+
+```html
+<!-- Preferred -->
+<div class="{attributes.isVisible ? 'show' : ''}"></div>
+```
+
+This gives consistent results in both PHP and JavaScript renderers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jverneaut/html-to-gutenberg",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jverneaut/html-to-gutenberg",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
+        "acorn": "^8.14.1",
         "chalk": "^5.4.1",
         "chokidar": "^4.0.3",
         "commander": "^13.1.0",
@@ -2562,6 +2563,18 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jest": "^29.7.0"
   },
   "dependencies": {
+    "acorn": "^8.14.1",
     "chalk": "^5.4.1",
     "chokidar": "^4.0.3",
     "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jverneaut/html-to-gutenberg",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "index.js",
   "engines": {
     "node": ">=20.0.0"

--- a/src/processors/global/GlobalAttributeExpression.js
+++ b/src/processors/global/GlobalAttributeExpression.js
@@ -1,0 +1,220 @@
+import ProcessorBase from "#processors/ProcessorBase.js";
+import PrinterEditJS from "#printers/PrinterEditJS.js";
+import PrinterRenderPHP from "#printers/PrinterRenderPHP.js";
+
+import { visit } from "unist-util-visit";
+import { parseExpressionAt } from "acorn";
+
+import { getDataBindInfo } from "#utils-string/index.js";
+import { DATA_BIND_TYPES } from "#constants";
+
+const parseDslString = (input) => {
+  const result = [];
+  const regex = /\{([^}]*)\}/g;
+  let lastIndex = 0;
+  let match;
+
+  while ((match = regex.exec(input)) !== null) {
+    if (match.index > lastIndex) {
+      result.push({
+        type: "text",
+        value: input.slice(lastIndex, match.index),
+      });
+    }
+
+    result.push({
+      type: "expression",
+      value: match[1].trim(),
+    });
+
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < input.length) {
+    result.push({
+      type: "text",
+      value: input.slice(lastIndex),
+    });
+  }
+
+  return result;
+};
+
+const extractReferences = (expr) => {
+  const refs = [];
+
+  const walk = (node, path = []) => {
+    switch (node.type) {
+      case "Identifier":
+        refs.push(path.concat(node.name).join("."));
+        break;
+      case "MemberExpression":
+        if (node.computed) return;
+        const parts = [];
+        let cur = node;
+        while (cur.type === "MemberExpression") {
+          if (cur.property.type !== "Identifier" || cur.computed) return;
+          parts.unshift(cur.property.name);
+          cur = cur.object;
+        }
+        if (cur.type === "Identifier") {
+          parts.unshift(cur.name);
+          refs.push(parts.join("."));
+        }
+        break;
+      case "ConditionalExpression":
+        walk(node.test);
+        walk(node.consequent);
+        walk(node.alternate);
+        break;
+      case "BinaryExpression":
+      case "LogicalExpression":
+        walk(node.left);
+        walk(node.right);
+        break;
+      case "CallExpression":
+        walk(node.callee);
+        node.arguments.forEach(walk);
+        break;
+      default:
+        break;
+    }
+  };
+
+  try {
+    const ast = parseExpressionAt(expr, 0, { ecmaVersion: 2020 });
+    walk(ast);
+  } catch (e) {
+    console.error("Parse error:", e.message);
+  }
+
+  return [...new Set(refs)];
+};
+
+const mapReferenceToJS = (ref, instance) => {
+  const dataBindInfo = getDataBindInfo(ref);
+
+  if (dataBindInfo.type === DATA_BIND_TYPES.attributes) {
+    instance.blockData._hasAttributesProps = true;
+
+    return `attributes.${dataBindInfo.key}`;
+  }
+
+  if (dataBindInfo.type === DATA_BIND_TYPES.postMeta) {
+    instance.blockData._hasPostType = true;
+    instance.blockData._hasPostMeta = true;
+
+    return `meta.${dataBindInfo.key}`;
+  }
+
+  if (dataBindInfo.type === DATA_BIND_TYPES.postTitle) {
+    instance.blockData._hasPostType = true;
+    instance.blockData._hasPostTitle = true;
+
+    return `postTitle`;
+  }
+
+  return ref;
+};
+
+const mapReferenceToPhp = (ref) => {
+  const dataBindInfo = getDataBindInfo(ref);
+
+  if (dataBindInfo.type === DATA_BIND_TYPES.attributes) {
+    return `($attributes['${dataBindInfo.key}'] ?? '')`;
+  }
+
+  if (dataBindInfo.type === DATA_BIND_TYPES.postMeta) {
+    return `(get_post_meta(get_the_ID(), '${dataBindInfo.key}', true))`;
+  }
+
+  if (dataBindInfo.type === DATA_BIND_TYPES.postTitle) {
+    return `(get_the_title())`;
+  }
+
+  return ref;
+};
+
+const printJs = (ir, referenceMap) => {
+  return (
+    "`" +
+    ir
+      .map((part) => {
+        if (part.type === "text") {
+          return part.value.replace(/[`\\$]/g, "\\$&");
+        }
+
+        let expr = part.value;
+        for (const ref of Object.keys(referenceMap)) {
+          expr = expr.replaceAll(ref, referenceMap[ref]);
+        }
+
+        return `\${${expr}}`;
+      })
+      .join("") +
+    "`"
+  );
+};
+
+const printPhp = (ir, referenceMap = {}) => {
+  return ir
+    .map((part) => {
+      if (part.type === "text") {
+        return `"${part.value}"`;
+      }
+
+      let expr = part.value;
+      for (const ref of Object.keys(referenceMap)) {
+        expr = expr.replaceAll(ref, referenceMap[ref]);
+      }
+
+      return `(${expr})`;
+    })
+    .join(" . ");
+};
+
+export default class GlobalAttributeExpression extends ProcessorBase {
+  processAstByFilename(filename) {
+    if (
+      filename === PrinterEditJS.filename ||
+      filename === PrinterRenderPHP.filename
+    ) {
+      visit(this.asts[filename], "element", (node) => {
+        Object.entries(node.properties).forEach(([key, value]) => {
+          if (typeof value === "boolean") return;
+
+          const attrValue = Array.isArray(value) ? value.join(" ") : value;
+          if (attrValue.startsWith("$$")) return;
+
+          const ir = parseDslString(attrValue);
+
+          const hasExpression = ir.some((part) => part.type === "expression");
+          if (!hasExpression) return;
+
+          const allRefs = ir
+            .filter((p) => p.type === "expression")
+            .flatMap((p) => extractReferences(p.value));
+
+          const jsReferenceMap = Object.fromEntries(
+            [...new Set(allRefs)].map((r) => [r, mapReferenceToJS(r, this)]),
+          );
+
+          const phpReferenceMap = Object.fromEntries(
+            [...new Set(allRefs)].map((r) => [r, mapReferenceToPhp(r)]),
+          );
+
+          const jsValue = "$${" + printJs(ir, jsReferenceMap) + "}$$";
+          const phpValue = "<?= " + printPhp(ir, phpReferenceMap) + "; ?>";
+
+          if (filename === PrinterEditJS.filename) {
+            node.properties[key] = jsValue;
+          }
+
+          if (filename === PrinterRenderPHP.filename) {
+            node.properties[key] = phpValue;
+          }
+        });
+      });
+    }
+  }
+}

--- a/src/processors/index.js
+++ b/src/processors/index.js
@@ -17,6 +17,7 @@ import CustomElementToolbarItem from "./custom-elements/CustomElementToolbarItem
 
 import DataBind from "./data-bind/index.js";
 
+import GlobalAttributeExpression from "./global/GlobalAttributeExpression.js";
 import GlobalDepreciations from "./global/GlobalDepreciations.js";
 import GlobalErrors from "./global/GlobalErrors.js";
 import GlobalJSXAttributes from "./global/GlobalJSXAttributes.js";
@@ -46,6 +47,7 @@ export default [
   CustomElementToolbarGroup,
   CustomElementToolbarItem,
 
+  GlobalAttributeExpression,
   GlobalJSXAttributes,
   GlobalRawExpressions,
 ];


### PR DESCRIPTION
Attributes now supports expressions inside curly braces. They need to be readable by PHP and JS, so those expressions work:
- `<div class="hero hero--{attributes.heroType}"></div>`
- `<div class="hero hero--{attributes.reversed ? 'reversed' : ''}"></div>`
- `<div class="hero hero--{postMeta.postStatus === 'promoted' ? 'promoted' : ''}"></div>`

The usual data binding syntax applies, so `[attributeName]`, `attributes.[attributeName]`, `postMeta.[metaKey]` and `post.title` all work as expected. Any reference outside this scope will throw an error.