### PR TITLE
53 Allow defining block-controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,17 @@
 
 # HTML To Gutenberg
 
-**HTML To Gutenberg** is a powerful Webpack plugin that transforms HTML files into fully functional _native_ WordPress Gutenberg blocks, automatically generating all the necessary files like `edit.js`, `render.php`, `block.json`, and `index.js` for you.
+**HTML to Gutenberg** is a Webpack plugin that compiles your HTML into real, native Gutenberg blocks. No shortcodes. No server-side hacks. _The real Gutenberg editing experience._
 
-Designed for developers who want **simplicity and speed without sacrificing control**, it enables you to keep your familiar HTML workflow while seamlessly integrating with the **native WordPress block editor experience**. Just add a few intuitive attributes to your markup, and the plugin takes care of the rest — **no React knowledge required**.
+It generates proper `edit.js`, `render.php`, `block.json`, and `index.js` files, exactly what you'd write by hand if you were building blocks with React and PHP.
 
-[Try it out in the Live Editor](https://html-to-gutenberg.com/live-editor) to see how quickly you can convert your HTML into reusable Gutenberg blocks.
+**But you won’t have to write a single line of React or PHP.**
+
+Just structure your HTML with a few intuitive attributes, and let the plugin handle the heavy lifting.
+
+The output is 100% native Gutenberg code. If you stop using the plugin, your blocks still work. No lock-in.
+
+[Try it out in the Live Editor](https://html-to-gutenberg.com/live-editor) to see how quickly you can convert your HTML into Gutenberg blocks.
 
 
 ![HTML To Gutenberg WordCamp Demo](docs/static/img/wordcamp-demo.png)

--- a/__tests__/fixtures/processable/block-controls/expected.index.js
+++ b/__tests__/fixtures/processable/block-controls/expected.index.js
@@ -1,0 +1,9 @@
+import { registerBlockType } from "@wordpress/blocks";
+
+import Edit from "./edit.js";
+import metadata from "./block.json";
+
+registerBlockType(metadata.name, {
+  edit: Edit,
+  save: () => null,
+});

--- a/__tests__/fixtures/processable/block-controls/expected.js
+++ b/__tests__/fixtures/processable/block-controls/expected.js
@@ -1,0 +1,95 @@
+import { useBlockProps, BlockControls } from "@wordpress/block-editor";
+import {
+  ToolbarGroup,
+  ToolbarButton,
+  ToolbarDropdownMenu,
+} from "@wordpress/components";
+import { useSelect } from "@wordpress/data";
+import { useEntityProp } from "@wordpress/core-data";
+import {
+  arrowUp,
+  arrowRight,
+  arrowDown,
+  arrowLeft,
+  styles,
+  formatBold,
+  more,
+} from "@wordpress/icons";
+
+export default ({ attributes, setAttributes }) => {
+  const postType = useSelect(
+    (select) => select("core/editor").getCurrentPostType(),
+    [],
+  );
+
+  const [meta, setMeta] = useEntityProp("postType", postType, "meta");
+
+  return (
+    <section {...useBlockProps()}>
+      <BlockControls>
+        <ToolbarGroup>
+          <ToolbarButton
+            icon={styles}
+            isActive={attributes.darkMode}
+            onClick={() => setAttributes({ darkMode: !attributes.darkMode })}
+          ></ToolbarButton>
+          <ToolbarButton
+            icon={formatBold}
+            isActive={meta.bold}
+            onClick={() => setMeta({ ...meta, bold: !meta.bold })}
+          ></ToolbarButton>
+        </ToolbarGroup>
+
+        <ToolbarGroup>
+          <ToolbarDropdownMenu
+            icon={more}
+            label="Select a direction"
+            controls={[
+              {
+                title: "Up",
+                icon: arrowUp,
+                isActive: attributes.direction === "up",
+                onClick: () => setAttributes({ direction: "up" }),
+              },
+              {
+                title: "Right",
+                icon: arrowRight,
+                isActive: attributes.direction === "right",
+                onClick: () => setAttributes({ direction: "right" }),
+              },
+              {
+                title: "Down",
+                icon: arrowDown,
+                isActive: attributes.direction === "down",
+                onClick: () => setAttributes({ direction: "down" }),
+              },
+              {
+                title: "Left",
+                icon: arrowLeft,
+                isActive: attributes.direction === "left",
+                onClick: () => setAttributes({ direction: "left" }),
+              },
+            ]}
+          ></ToolbarDropdownMenu>
+
+          <ToolbarDropdownMenu
+            icon={more}
+            label="Select a size"
+            controls={[
+              {
+                title: "Small",
+                isActive: meta.size === "small",
+                onClick: () => setMeta({ ...meta, size: "small" }),
+              },
+              {
+                title: "big",
+                isActive: meta.size === "big",
+                onClick: () => setMeta({ ...meta, size: "big" }),
+              },
+            ]}
+          ></ToolbarDropdownMenu>
+        </ToolbarGroup>
+      </BlockControls>
+    </section>
+  );
+};

--- a/__tests__/fixtures/processable/block-controls/expected.json
+++ b/__tests__/fixtures/processable/block-controls/expected.json
@@ -1,0 +1,18 @@
+{
+  "name": "custom/input",
+  "title": "Input",
+  "textdomain": "input",
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "version": "0.1.0",
+  "category": "theme",
+  "example": {},
+  "attributes": {
+    "align": { "type": "string", "default": "full" },
+    "darkMode": { "type": "boolean" },
+    "direction": { "type": "string", "default": "up" }
+  },
+  "supports": { "html": false, "align": ["full"] },
+  "editorScript": "file:./index.js",
+  "render": "file:./render.php"
+}

--- a/__tests__/fixtures/processable/block-controls/expected.php
+++ b/__tests__/fixtures/processable/block-controls/expected.php
@@ -1,0 +1,2 @@
+<section <?php echo get_block_wrapper_attributes(); ?>>
+</section>

--- a/__tests__/fixtures/processable/block-controls/input.html
+++ b/__tests__/fixtures/processable/block-controls/input.html
@@ -1,0 +1,45 @@
+<section>
+  <block-controls>
+    <toolbar-group>
+      <toolbar-button data-bind="darkMode" icon="styles"></toolbar-button>
+      <toolbar-button
+        data-bind="postMeta.bold"
+        icon="formatBold"
+      ></toolbar-button>
+    </toolbar-group>
+
+    <toolbar-group>
+      <toolbar-dropdown-menu
+        icon="more"
+        label="Select a direction"
+        data-bind="direction"
+      >
+        <toolbar-dropdown-menu-option icon="arrowUp" value="up"
+          >Up</toolbar-dropdown-menu-option
+        >
+        <toolbar-dropdown-menu-option icon="arrowRight" value="right"
+          >Right</toolbar-dropdown-menu-option
+        >
+        <toolbar-dropdown-menu-option icon="arrowDown" value="down"
+          >Down</toolbar-dropdown-menu-option
+        >
+        <toolbar-dropdown-menu-option icon="arrowLeft" value="left"
+          >Left</toolbar-dropdown-menu-option
+        >
+      </toolbar-dropdown-menu>
+
+      <toolbar-dropdown-menu
+        icon="more"
+        label="Select a size"
+        data-bind="postMeta.size"
+      >
+        <toolbar-dropdown-menu-option value="small"
+          >Small</toolbar-dropdown-menu-option
+        >
+        <toolbar-dropdown-menu-option value="big"
+          >big</toolbar-dropdown-menu-option
+        >
+      </toolbar-dropdown-menu>
+    </toolbar-group>
+  </block-controls>
+</section>

--- a/docs/docs/common/_introduction.md
+++ b/docs/docs/common/_introduction.md
@@ -1,5 +1,11 @@
-**HTML To Gutenberg** is a powerful Webpack plugin that transforms HTML files into fully functional _native_ WordPress Gutenberg blocks, automatically generating all the necessary files like `edit.js`, `render.php`, `block.json`, and `index.js` for you.
+**HTML to Gutenberg** is a Webpack plugin that compiles your HTML into real, native Gutenberg blocks. No shortcodes. No server-side hacks. _The real Gutenberg editing experience._
 
-Designed for developers who want **simplicity and speed without sacrificing control**, it enables you to keep your familiar HTML workflow while seamlessly integrating with the **native WordPress block editor experience**. Just add a few intuitive attributes to your markup, and the plugin takes care of the rest — **no React knowledge required**.
+It generates proper `edit.js`, `render.php`, `block.json`, and `index.js` files, exactly what you'd write by hand if you were building blocks with React and PHP.
 
-[Try it out in the Live Editor](https://html-to-gutenberg.com/live-editor) to see how quickly you can convert your HTML into reusable Gutenberg blocks.
+**But you won’t have to write a single line of React or PHP.**
+
+Just structure your HTML with a few intuitive attributes, and let the plugin handle the heavy lifting.
+
+The output is 100% native Gutenberg code. If you stop using the plugin, your blocks still work. No lock-in.
+
+[Try it out in the Live Editor](https://html-to-gutenberg.com/live-editor) to see how quickly you can convert your HTML into Gutenberg blocks.

--- a/docs/docs/guides/block-controls.mdx
+++ b/docs/docs/guides/block-controls.mdx
@@ -1,0 +1,67 @@
+---
+siderbar_position: 7
+---
+
+import CodeExample from "@site/src/components/CodeExample";
+
+# Adding BlockControls to the toolbar
+
+**HTML to Gutenberg** supports a limited set of toolbar controls using the `<block-controls>` custom element, which maps directly to the native Gutenberg `BlockControls` component.
+
+## Toolbar control groups
+
+Use `<toolbar-group>` to organize your toolbar controls into groups:
+
+<CodeExample>
+  ```
+  <section>
+    <block-controls>
+      <toolbar-group>
+        <!-- Your grouped controls here -->
+      </toolbar-group>
+    </block-controls>
+  </section>
+  ```
+</CodeExample>
+
+## Supported Toolbar Controls
+
+HTML to Gutenberg supports the following toolbar controls:
+
+- `<toolbar-button>` — Toggle a boolean value.
+- `<toolbar-dropdown-menu>` — Choose from a set of options.
+
+These elements can be [data-bound](data-binding.mdx) to block attributes or post meta using `data-bind`.
+
+## Behavior
+
+- `<toolbar-button>`:
+
+  **Acts as a toggle**. When bound with data-bind, it toggles the associated boolean attribute.
+
+- `<toolbar-dropdown-menu>`:
+
+  **Acts like a `<select>`**. Options are defined using `<toolbar-dropdown-menu-option>`.
+
+<CodeExample>
+  ```
+  <section>
+    <block-controls>
+      <toolbar-group>
+        <toolbar-button data-bind="darkMode" icon="styles"></toolbar-button>
+        <toolbar-dropdown-menu
+          icon="more"
+          label="Select a direction"
+          data-bind="direction"
+        >
+          <toolbar-dropdown-menu-option icon="arrowUp" value="up">Up</toolbar-dropdown-menu-option>
+          <toolbar-dropdown-menu-option icon="arrowRight" value="right">Right</toolbar-dropdown-menu-option>
+          <toolbar-dropdown-menu-option icon="arrowDown" value="down">Down</toolbar-dropdown-menu-option>
+          <toolbar-dropdown-menu-option icon="arrowLeft" value="left">Left</toolbar-dropdown-menu-option>
+        </toolbar-dropdown-menu>
+      </toolbar-group>
+    </block-controls>
+
+  </section>
+  ```
+</CodeExample>

--- a/docs/docs/guides/expressions.mdx
+++ b/docs/docs/guides/expressions.mdx
@@ -1,3 +1,7 @@
+---
+siderbar_position: 9
+---
+
 # Using logical expressions inside attributes
 
 **HTML To Gutenberg** supports using JavaScript-like expressions directly inside HTML attributes. These expressions are dynamically evaluated in both **JavaScript (for the editor)** and **PHP (for rendering on the front end)**.

--- a/docs/docs/guides/inspector-controls.mdx
+++ b/docs/docs/guides/inspector-controls.mdx
@@ -8,7 +8,7 @@ import CodeExample from "@site/src/components/CodeExample";
 
 Once your block looks the way you want, you might want to make it configurable to let editors choose options, or adjust content.
 
-**HTML to Gutenberg** lets you do that using `<inspector-controls>`, a custom element that maps directly to the native Gutenberg component.
+**HTML to Gutenberg** lets you do that using `<inspector-controls>`, a custom element that maps directly to the native Gutenberg `InspectorControls` component.
 
 ## Adding panels
 

--- a/docs/docs/guides/inspector-controls.mdx
+++ b/docs/docs/guides/inspector-controls.mdx
@@ -1,5 +1,5 @@
 ---
-siderbar_position: 7
+siderbar_position: 8
 ---
 
 import CodeExample from "@site/src/components/CodeExample";
@@ -18,8 +18,12 @@ Use `<panel-body>` to group your controls into collapsible panels in the block s
   ```
   <section>
     <inspector-controls>
-      <panel-body title="Query settings"><!-- ... --></panel-body>
-      <panel-body title="Display settings"><!-- ... --></panel-body>
+      <panel-body title="Query settings">
+        <!-- ... -->
+      </panel-body>
+      <panel-body title="Display settings">
+        <!-- ... -->
+      </panel-body>
     </inspector-controls>
   </section>
   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jverneaut/html-to-gutenberg",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jverneaut/html-to-gutenberg",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "index.js",
   "engines": {
     "node": ">=20.0.0"

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ export const DATA_BIND_CONTROLS_ELEMENTS = [
   "text-control",
   "toggle-control",
   "select-control",
+  "toolbar-button",
 ];
 
 export const DATA_BIND_WITH_OPTIONS_ELEMENTS = [

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,12 +8,14 @@ export const DATA_BIND_CONTROLS_ELEMENTS = [
   "toggle-control",
   "select-control",
   "toolbar-button",
+  "toolbar-dropdown-menu",
 ];
 
 export const DATA_BIND_WITH_OPTIONS_ELEMENTS = [
   "select",
   "select-control",
   "radio-control",
+  "toolbar-dropdown-menu",
 ];
 
 export const DATA_BIND_NON_RICH_TEXT_ELEMENTS = [

--- a/src/getDefaultBlockData.js
+++ b/src/getDefaultBlockData.js
@@ -29,6 +29,7 @@ const defaultBlockData = {
 
   _boundImages: [], // {key: string, type: string, size?: string}[]
   _dependencies: [], // string[],
+  _icons: [], // string[]
 
   // Block.json metadata
   name: null,

--- a/src/getDefaultBlockData.js
+++ b/src/getDefaultBlockData.js
@@ -16,6 +16,7 @@ const defaultBlockData = {
   _hasToolbarItemImport: false,
   _hasToolbarGroupImport: false,
   _hasToolbarButtonImport: false,
+  _hasToolbarDropdownMenuImport: false,
   _hasBlockControlsImport: false,
 
   _hasWordPressComponents: false,

--- a/src/printers/PrinterEditJS.js
+++ b/src/printers/PrinterEditJS.js
@@ -59,6 +59,9 @@ ToolbarGroup,
 {{#_hasToolbarButtonImport}}
 ToolbarButton,
 {{/_hasToolbarButtonImport}}
+{{#_hasToolbarDropdownMenuImport}}
+ToolbarDropdownMenu,
+{{/_hasToolbarDropdownMenuImport}}
 } from '@wordpress/components';
 {{/_hasWordPressComponents}}
 {{#_hasPostType}}

--- a/src/printers/PrinterEditJS.js
+++ b/src/printers/PrinterEditJS.js
@@ -72,7 +72,7 @@ import { Image } from "@10up/block-components/components/image";
 {{#_hasServerSideRender}}
 import ServerSideRender from '@wordpress/server-side-render';
 {{/_hasServerSideRender}}
-
+{{#iconsString}}{{{iconsString}}}{{/iconsString}}
 {{#editorStyle}}
 import './{{{editorStyle}}}';
 {{/editorStyle}}
@@ -117,9 +117,18 @@ export default class PrinterEditJS extends PrinterBase {
 
     const propsString = props.length ? `{${props.join(", ")}}` : "";
 
+    const iconsString = this.blockData._icons.length
+      ? [
+          "import {",
+          ...[...new Set(this.blockData._icons)].map((icon) => `${icon},`),
+          "} from '@wordpress/icons';\n",
+        ].join("\n")
+      : false;
+
     const renderedTemplate = Mustache.render(template, {
       content: htmlString,
       propsString,
+      iconsString,
       ...this.blockData,
     });
 

--- a/src/processors/attributes/AttributeIcon.js
+++ b/src/processors/attributes/AttributeIcon.js
@@ -1,0 +1,22 @@
+import ProcessorBase from "#processors/ProcessorBase.js";
+import PrinterEditJS from "#printers/PrinterEditJS.js";
+
+import { visit } from "unist-util-visit";
+
+export default class AttributeIcon extends ProcessorBase {
+  processAstByFilename(filename) {
+    if (filename === PrinterEditJS.filename) {
+      visit(this.asts[filename], "element", (node) => {
+        // If the node is a React component (starts with a capital letter)
+        if (node.tagName.charAt(0) === node.tagName.charAt(0).toUpperCase()) {
+          if (node.properties.icon) {
+            const icon = node.properties.icon.trim();
+            this.blockData._icons.push(icon);
+
+            node.properties.icon = `$\${${icon}}$$`;
+          }
+        }
+      });
+    }
+  }
+}

--- a/src/processors/custom-elements/CustomElementToolbar.js
+++ b/src/processors/custom-elements/CustomElementToolbar.js
@@ -8,6 +8,7 @@ export default class CustomElementToolbar extends JSXElementTransformer {
   static HTMLTagName = "toolbar";
 
   onMatch(node) {
+    this.blockData._hasWordPressComponents = true;
     this.blockData._hasToolbarImport = true;
   }
 

--- a/src/processors/custom-elements/CustomElementToolbarButton.js
+++ b/src/processors/custom-elements/CustomElementToolbarButton.js
@@ -8,6 +8,7 @@ export default class CustomElementToolbarButton extends JSXElementTransformer {
   static HTMLTagName = "toolbar-button";
 
   onMatch(node) {
+    this.blockData._hasWordPressComponents = true;
     this.blockData._hasToolbarButtonImport = true;
   }
 

--- a/src/processors/custom-elements/CustomElementToolbarDropdownMenu.js
+++ b/src/processors/custom-elements/CustomElementToolbarDropdownMenu.js
@@ -1,0 +1,22 @@
+import JSXElementTransformer from "./CustomElementJSXTransformer.js";
+
+import PrinterRenderPHP from "#printers/PrinterRenderPHP.js";
+import { deleteTagName, getOptions } from "#utils-html/index.js";
+
+export default class CustomElementToolbarButton extends JSXElementTransformer {
+  static JSXTagName = "ToolbarDropdownMenu";
+  static HTMLTagName = "toolbar-dropdown-menu";
+
+  onMatch(node) {
+    this.blockData._hasWordPressComponents = true;
+    this.blockData._hasToolbarDropdownMenuImport = true;
+  }
+
+  processAstByFilename(filename) {
+    super.processAstByFilename(filename);
+
+    if (filename === PrinterRenderPHP.filename) {
+      deleteTagName(this.asts[filename], this.constructor.HTMLTagName);
+    }
+  }
+}

--- a/src/processors/custom-elements/CustomElementToolbarGroup.js
+++ b/src/processors/custom-elements/CustomElementToolbarGroup.js
@@ -8,6 +8,7 @@ export default class CustomElementToolbarGroup extends JSXElementTransformer {
   static HTMLTagName = "toolbar-group";
 
   onMatch(node) {
+    this.blockData._hasWordPressComponents = true;
     this.blockData._hasToolbarGroupImport = true;
   }
 

--- a/src/processors/custom-elements/CustomElementToolbarItem.js
+++ b/src/processors/custom-elements/CustomElementToolbarItem.js
@@ -8,6 +8,7 @@ export default class CustomElementToolbarItem extends JSXElementTransformer {
   static HTMLTagName = "toolbar-item";
 
   onMatch(node) {
+    this.blockData._hasWordPressComponents = true;
     this.blockData._hasToolbarItemImport = true;
   }
 

--- a/src/processors/data-bind/DataBindControls.js
+++ b/src/processors/data-bind/DataBindControls.js
@@ -10,7 +10,7 @@ import {
   DATA_BIND_TYPES,
 } from "../../constants.js";
 
-export default class DataBindInspectorControls extends ProcessorBase {
+export default class DataBindControls extends ProcessorBase {
   processAstByFilename(printerFilename) {
     if (printerFilename === PrinterEditJS.filename) {
       visit(this.asts[printerFilename], "element", (node) => {
@@ -63,6 +63,24 @@ export default class DataBindInspectorControls extends ProcessorBase {
               if (dataBindInfo.type === DATA_BIND_TYPES.postMeta) {
                 node.properties.selected = `$\${meta.${dataBindInfo.key}}$$`;
                 node.properties.onChange = `$\${(${dataBindInfo.key}) => setMeta({ ...meta, ${dataBindInfo.key} })}$$`;
+              }
+
+              break;
+
+            case "toolbar-button":
+              if (dataBindInfo.type === DATA_BIND_TYPES.attributes) {
+                this.blockData.attributes = {
+                  ...this.blockData.attributes,
+                  [dataBindInfo.key]: getAttributeDeclaration(node, "boolean"),
+                };
+
+                node.properties.isActive = `$\${attributes.${dataBindInfo.key}}$$`;
+                node.properties.onClick = `$\${() => setAttributes({ ${dataBindInfo.key}: !attributes.${dataBindInfo.key} })}$$`;
+              }
+
+              if (dataBindInfo.type === DATA_BIND_TYPES.postMeta) {
+                node.properties.isActive = `$\${meta.${dataBindInfo.key}}$$`;
+                node.properties.onClick = `$\${() => setMeta({ ...meta, ${dataBindInfo.key}: !meta.${dataBindInfo.key} })}$$`;
               }
 
               break;

--- a/src/processors/data-bind/index.js
+++ b/src/processors/data-bind/index.js
@@ -2,7 +2,7 @@ import ProcessorBase from "#processors/ProcessorBase.js";
 
 import DataBindImageProcessor from "./DataBindImage.js";
 import DataBindInputProcessor from "./DataBindInput.js";
-import DataBindInspectorControlsProcessor from "./DataBindInspectorControls.js";
+import DataBindControlsProcessor from "./DataBindControls.js";
 import DataBindRichTextProcessor from "./DataBindRichText.js";
 
 export default class DataBind extends ProcessorBase {
@@ -10,7 +10,7 @@ export default class DataBind extends ProcessorBase {
     return [
       DataBindImageProcessor,
       DataBindInputProcessor,
-      DataBindInspectorControlsProcessor,
+      DataBindControlsProcessor,
       DataBindRichTextProcessor,
     ];
   }

--- a/src/processors/index.js
+++ b/src/processors/index.js
@@ -3,6 +3,7 @@ import RootBlockWrapperAttributes from "./root/RootBlockWrapperAttributes.js";
 import RootUseBlockProps from "./root/RootUseBlockProps.js";
 
 import AttributeDataDisplay from "./attributes/AttributeDataDisplay.js";
+import AttributeIcon from "./attributes/AttributeIcon.js";
 import AttributeStyle from "./attributes/AttributeStyle.js";
 
 import CustomElementBlockControls from "./custom-elements/CustomElementBlockControls.js";
@@ -46,6 +47,8 @@ export default [
   CustomElementToolbarButton,
   CustomElementToolbarGroup,
   CustomElementToolbarItem,
+
+  AttributeIcon,
 
   GlobalAttributeExpression,
   GlobalJSXAttributes,

--- a/src/processors/index.js
+++ b/src/processors/index.js
@@ -13,6 +13,7 @@ import CustomElementRootBlockAttribute from "./custom-elements/CustomElementRoot
 import CustomElementServerBlock from "./custom-elements/CustomElementServerBlock.js";
 import CustomElementToolbar from "./custom-elements/CustomElementToolbar.js";
 import CustomElementToolbarButton from "./custom-elements/CustomElementToolbarButton.js";
+import CustomElementToolbarDropdownMenu from "./custom-elements/CustomElementToolbarDropdownMenu.js";
 import CustomElementToolbarGroup from "./custom-elements/CustomElementToolbarGroup.js";
 import CustomElementToolbarItem from "./custom-elements/CustomElementToolbarItem.js";
 
@@ -45,6 +46,7 @@ export default [
   CustomElementServerBlock,
   CustomElementToolbar,
   CustomElementToolbarButton,
+  CustomElementToolbarDropdownMenu,
   CustomElementToolbarGroup,
   CustomElementToolbarItem,
 

--- a/src/utils-html/getOptions.js
+++ b/src/utils-html/getOptions.js
@@ -6,6 +6,8 @@ export default (node) => {
 
   visit(node, "element", (node) => {
     if (node.tagName.endsWith("-option")) {
+      const option = {};
+
       const label = node.children
         ? toHtml(node.children)
             .trim()
@@ -14,26 +16,32 @@ export default (node) => {
             .join(" ")
         : false;
 
+      if (node.properties?.icon) {
+        option.icon = node.properties.icon.trim();
+      }
+
       if (node.properties?.value !== undefined) {
         if (label) {
-          options.push({
+          Object.assign(option, {
             label: label,
             value: node.properties?.value,
           });
         } else {
-          options.push({
-            label: node.properties.value,
-            value: node.properties.value,
+          Object.assign(option, {
+            label: node.properties?.value,
+            value: node.properties?.value,
           });
         }
       } else {
         if (label) {
-          options.push({
+          Object.assign(option, {
             label: label,
             value: label,
           });
         }
       }
+
+      options.push(option);
     }
   });
 


### PR DESCRIPTION
This PR adds support for adding and data-binding to `<toolbar-button>` and `<toolbar-dropdown-menu>`.

## TODO

- [x] - Add documentation